### PR TITLE
Add age-range configuration to census authorization verifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "decidim-conferences", DECIDIM_VERSION
 gem "decidim-decidim_awesome", github: "decidim-ice/decidim-module-decidim_awesome", branch: "main"
 gem "decidim-extra_user_fields", github: "openpoke/decidim-module-extra_user_fields", branch: "main"
 gem "decidim-pokecode", github: "openpoke/decidim-module-pokecode", branch: "main"
+gem "decidim-templates", DECIDIM_VERSION
 gem "decidim-term_customizer", github: "openpoke/decidim-module-term_customizer", branch: "main"
 
 gem "bootsnap", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,6 +231,9 @@ GIT
       devise (~> 4.7)
       devise-i18n (~> 1.2)
       devise_invitable (~> 2.0, >= 2.0.9)
+    decidim-templates (0.31.3)
+      decidim-core (= 0.31.3)
+      decidim-forms (= 0.31.3)
     decidim-verifications (0.31.3)
       decidim-core (= 0.31.3)
 
@@ -1099,6 +1102,7 @@ DEPENDENCIES
   decidim-dev!
   decidim-extra_user_fields!
   decidim-pokecode!
+  decidim-templates!
   decidim-term_customizer!
   letter_opener_web
   listen
@@ -1189,6 +1193,7 @@ CHECKSUMS
   decidim-sortitions (0.31.3)
   decidim-surveys (0.31.3)
   decidim-system (0.31.3)
+  decidim-templates (0.31.3)
   decidim-term_customizer (0.31)
   decidim-verifications (0.31.3)
   declarative-builder (0.2.0) sha256=2a46988c32b97c9e77c7739b7bbdd4ab7042c9584836c4abf5ac90024af6f1af

--- a/app/forms/concerns/permission_form_override.rb
+++ b/app/forms/concerns/permission_form_override.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PermissionFormOverride
+  extend ActiveSupport::Concern
+
+  included do
+    validate :handler_options_values_must_be_valid
+  end
+
+  private
+
+  def handler_options_values_must_be_valid
+    authorization_handlers_names.each do |handler_name|
+      next if handler_name.blank?
+      next unless manifest(handler_name)
+
+      schema = options_schema(handler_name)
+      next if schema.valid?
+
+      schema.errors.each do |error|
+        errors.add(:base, humanized_options_error(handler_name, error))
+      end
+    end
+  end
+
+  def humanized_options_error(handler_name, error)
+    label = I18n.t(
+      error.attribute,
+      scope: "decidim.authorization_handlers.#{handler_name}.fields",
+      default: error.attribute.to_s.humanize
+    )
+    "#{label}: #{error.message}"
+  end
+end

--- a/app/overrides/decidim/admin/resource_permissions/edit/add_snippets.html.erb.deface
+++ b/app/overrides/decidim/admin/resource_permissions/edit/add_snippets.html.erb.deface
@@ -1,4 +1,4 @@
 <!-- insert_before 'section#components' -->
 
-<% append_stylesheet_pack_tag "decidim_admin_getxo_selects" %>
-<% append_javascript_pack_tag "decidim_admin_getxo_selects" %>
+<% append_stylesheet_pack_tag "decidim_admin_resource_permissions" %>
+<% append_javascript_pack_tag "decidim_admin_resource_permissions" %>

--- a/app/packs/entrypoints/decidim_admin_resource_permissions.js
+++ b/app/packs/entrypoints/decidim_admin_resource_permissions.js
@@ -1,2 +1,3 @@
 import "src/getxo/multiselect.js";
+import "src/getxo/age_inputs.js";
 import "stylesheets/decidim/multiselect.scss";

--- a/app/packs/src/getxo/age_inputs.js
+++ b/app/packs/src/getxo/age_inputs.js
@@ -1,0 +1,10 @@
+const AGE_INPUT_SELECTOR = 'input[name$="[minimum_age]"], input[name$="[maximum_age]"]';
+const NON_NEGATIVE_INTEGER_PATTERN = "^\\d+$";
+
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(AGE_INPUT_SELECTOR).forEach((input) => {
+    input.setAttribute("min", "0");
+    input.setAttribute("step", "1");
+    input.setAttribute("data-pattern", NON_NEGATIVE_INTEGER_PATTERN);
+  });
+});

--- a/app/services/census_action_authorizer.rb
+++ b/app/services/census_action_authorizer.rb
@@ -3,6 +3,7 @@
 class CensusActionAuthorizer < Decidim::Verifications::DefaultActionAuthorizer
   def authorize
     return [:missing, { action: :authorize }] if authorization.blank?
+    return [:unauthorized, {}] if age_restricted?
 
     return [:ok, {}] if zones.blank?
     return [:unauthorized, {}] if authorization_street.blank? || authorization_number.blank?
@@ -17,6 +18,34 @@ class CensusActionAuthorizer < Decidim::Verifications::DefaultActionAuthorizer
 
   def zones
     options["zones"]
+  end
+
+  def minimum_age
+    options["minimum_age"].to_i
+  end
+
+  def maximum_age
+    options["maximum_age"].to_i
+  end
+
+  def user_age
+    @user_age ||= begin
+      dob = Date.parse(authorization.metadata["date_of_birth"])
+      today = Date.current
+      age = today.year - dob.year
+      age -= 1 if today < dob + age.years
+      age
+    end
+  rescue ArgumentError, TypeError
+    nil
+  end
+
+  def age_restricted?
+    return false if minimum_age <= 0 && maximum_age <= 0
+    return false unless user_age
+
+    (minimum_age.positive? && user_age < minimum_age) ||
+      (maximum_age.positive? && user_age > maximum_age)
   end
 
   def authorization_street

--- a/app/services/census_authorization_handler.rb
+++ b/app/services/census_authorization_handler.rb
@@ -17,6 +17,8 @@ class CensusAuthorizationHandler < Decidim::AuthorizationHandler
   validate :document_number_valid
 
   def date_of_birth
+    return super if user.blank?
+
     Date.parse(user.extended_data["date_of_birth"]) if user.extended_data["date_of_birth"].present?
   end
 

--- a/config/assets.rb
+++ b/config/assets.rb
@@ -4,5 +4,5 @@ base_path = File.expand_path("..", __dir__)
 
 Decidim::Shakapacker.register_path("#{base_path}/app/packs")
 Decidim::Shakapacker.register_entrypoints(
-  resource_permissions_multiselect: "#{base_path}/app/packs/entrypoints/decidim_admin_getxo_selects.js"
+  resource_permissions: "#{base_path}/app/packs/entrypoints/decidim_admin_resource_permissions.js"
 )

--- a/config/initializers/getxo_customizations.rb
+++ b/config/initializers/getxo_customizations.rb
@@ -45,11 +45,23 @@ Decidim::Verifications.register_workflow(:census_authorization_handler) do |work
 
   workflow.options do |options|
     options.attribute :zones, type: :string
+    options.attribute :minimum_age, type: :integer, default: 0
+    options.attribute :maximum_age, type: :integer, default: 0
   end
+end
+
+Decidim::Verifications.find_workflow_manifest(:census_authorization_handler).options.schema.class_eval do
+  validates :minimum_age, :maximum_age,
+            numericality: { greater_than_or_equal_to: 0, allow_blank: true }
+
+  validates :maximum_age,
+            numericality: { greater_than_or_equal_to: :minimum_age },
+            if: -> { minimum_age.to_i.positive? && maximum_age.to_i.positive? }
 end
 
 Rails.application.config.to_prepare do
   # use captcha on signup
   Decidim::Devise::RegistrationsController.include(Decidim::Devise::RecaptchableSignUp)
   Decidim::LayoutHelper.prepend(LayoutHelperOverride)
+  Decidim::Admin::PermissionForm.include(PermissionFormOverride)
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,11 +11,13 @@ en:
         street_id: Street
   census_authorization:
     form:
-      document_number_help: This data is automatically sent to the census program to verify that the user is registered. Zeugaz Getxo does not store this data and cannot access it.
       date_select:
         day: Day
         month: Month
         year: Year
+      document_number_help: This data is automatically sent to the census program
+        to verify that the user is registered. Zeugaz Getxo does not store this data
+        and cannot access it.
   decidim:
     authorization_handlers:
       census_authorization_handler:
@@ -23,6 +25,8 @@ en:
         explanation: Verify your account with the municipal census
         fields:
           date_of_birth: Date of birth
+          maximum_age: Maximum age
+          minimum_age: Minimum age
           street: 'Street:'
           street_number: 'Street number:'
           zones: 'Valid zones:'
@@ -44,7 +48,6 @@ en:
               Listen to the music that will accompany the processes of participation
               from now on. Come and participate!
   getxo:
-    data_disclaimer_html: The data provided in this section is obtained from the municipal census and is used to verify that the user is registered in the census. Zeugaz Getxo does not store this data and cannot access it.
     admin:
       menu:
         census: Getxo Census
@@ -58,6 +61,9 @@ en:
           destroy: Delete
           edit: Edit
     connection_error: Connection error with the municipal census (%{error})
+    data_disclaimer_html: The data provided in this section is obtained from the municipal
+      census and is used to verify that the user is registered in the census. Zeugaz
+      Getxo does not store this data and cannot access it.
     street_sync_success: Streets synchronized correctly (%{count} streets received
       from the webservice)
   recaptcha:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -27,6 +27,8 @@ es:
         explanation: Verifica tu cuenta con el censo municipal
         fields:
           date_of_birth: Fecha de nacimiento
+          maximum_age: Edad máxima
+          minimum_age: Edad mínima
           street: 'Calle:'
           street_number: 'Número de calle:'
           zones: 'Zonas válidas:'

--- a/db/migrate/20260421090448_add_field_values_and_target_to_decidim_templates.decidim_templates.rb
+++ b/db/migrate/20260421090448_add_field_values_and_target_to_decidim_templates.decidim_templates.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This migration comes from decidim_templates (originally 20221006055954)
+class AddFieldValuesAndTargetToDecidimTemplates < ActiveRecord::Migration[6.0]
+  class Template < ApplicationRecord
+    self.table_name = :decidim_templates_templates
+  end
+
+  def change
+    add_column :decidim_templates_templates, :field_values, :json, default: {}
+    add_column :decidim_templates_templates, :target, :string
+
+    reversible do |direction|
+      direction.up do
+        # rubocop:disable Rails/SkipsModelValidations
+        Template.where(templatable_type: "Decidim::Forms::Questionnaire").update_all(target: "questionnaire")
+        Template.where(templatable_type: "Decidim::Organization").update_all(target: "user_block")
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_17_143021) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_21_090448) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
   enable_extension "pg_trgm"
@@ -1917,6 +1917,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_17_143021) do
     t.jsonb "description"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.json "field_values", default: {}
+    t.string "target"
     t.index ["decidim_organization_id"], name: "index_decidim_templates_organization"
     t.index ["templatable_type", "templatable_id"], name: "index_decidim_templates_templatable"
   end

--- a/package-lock.json
+++ b/package-lock.json
@@ -10877,37 +10877,6 @@
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
       }
     },
-    "node_modules/graphql-ws": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-6.0.5.tgz",
-      "integrity": "sha512-HzYw057ch0hx2gZjkbgk1pur4kAtgljlWRP+Gccudqm3BRrTpExjWCQ9OHdIsq47Y6lHL++1lTvuQHhgRRcevw==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@fastify/websocket": "^10 || ^11",
-        "crossws": "~0.3",
-        "graphql": "^15.10.1 || ^16",
-        "uWebSockets.js": "^20",
-        "ws": "^8"
-      },
-      "peerDependenciesMeta": {
-        "@fastify/websocket": {
-          "optional": true
-        },
-        "crossws": {
-          "optional": true
-        },
-        "uWebSockets.js": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",

--- a/spec/forms/decidim/admin/permission_form_override_spec.rb
+++ b/spec/forms/decidim/admin/permission_form_override_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Decidim::Admin::PermissionForm do
+  subject(:form) do
+    described_class.new(
+      authorization_handlers: selected_handlers,
+      authorization_handlers_options: handlers_options
+    )
+  end
+
+  let(:selected_handlers) { ["census_authorization_handler"] }
+  let(:handlers_options) do
+    { "census_authorization_handler" => { "minimum_age" => minimum_age, "maximum_age" => maximum_age } }
+  end
+  let(:minimum_age) { 18 }
+  let(:maximum_age) { 65 }
+
+  describe "validity by minimum_age input" do
+    [
+      { value: 0, valid: true, note: "zero (default)" },
+      { value: 18, valid: true, note: "positive integer within range" },
+      { value: -1, valid: false, note: "negative integer" },
+      { value: -999, valid: false, note: "large negative integer" },
+      { value: nil, valid: true, note: "nil" },
+      { value: "", valid: true, note: "empty string (blank)" },
+      { value: "18", valid: true, note: "numeric string" },
+      { value: "-7", valid: false, note: "negative numeric string" }
+    ].each do |row|
+      context "when minimum_age = #{row[:value].inspect} (#{row[:note]})" do
+        let(:minimum_age) { row[:value] }
+
+        if row[:valid]
+          it { is_expected.to be_valid }
+        else
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+
+  describe "validity by maximum_age input" do
+    [
+      { value: 0, valid: true },
+      { value: 65, valid: true },
+      { value: -1, valid: false },
+      { value: nil, valid: true },
+      { value: "", valid: true },
+      { value: "-5", valid: false }
+    ].each do |row|
+      context "when maximum_age = #{row[:value].inspect}" do
+        let(:maximum_age) { row[:value] }
+
+        if row[:valid]
+          it { is_expected.to be_valid }
+        else
+          it { is_expected.not_to be_valid }
+        end
+      end
+    end
+  end
+
+  describe "error reporting" do
+    context "when minimum_age is negative" do
+      let(:minimum_age) { -1 }
+
+      it "adds a :base error mentioning the field label" do
+        form.valid?
+        expect(form.errors[:base].join).to match(/Minimum age/i)
+      end
+    end
+
+    context "when maximum_age is negative" do
+      let(:maximum_age) { -5 }
+
+      it "adds a :base error mentioning the field label" do
+        form.valid?
+        expect(form.errors[:base].join).to match(/Maximum age/i)
+      end
+    end
+
+    context "when both values are invalid" do
+      let(:minimum_age) { -1 }
+      let(:maximum_age) { -5 }
+
+      it "reports both fields" do
+        form.valid?
+        messages = form.errors[:base].join
+        expect(messages).to match(/Minimum age/i)
+        expect(messages).to match(/Maximum age/i)
+      end
+    end
+  end
+
+  describe "cross-field range consistency" do
+    context "when maximum_age is less than minimum_age" do
+      let(:minimum_age) { 65 }
+      let(:maximum_age) { 18 }
+
+      it { is_expected.not_to be_valid }
+
+      it "reports the inconsistency" do
+        form.valid?
+        expect(form.errors[:base].join).to match(/Maximum age/i)
+      end
+    end
+
+    context "when maximum_age equals minimum_age" do
+      let(:minimum_age) { 18 }
+      let(:maximum_age) { 18 }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when minimum_age is 0 and maximum_age is less than minimum (still zero treated as not set)" do
+      let(:minimum_age) { 0 }
+      let(:maximum_age) { 0 }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when only minimum_age is set" do
+      let(:minimum_age) { 18 }
+      let(:maximum_age) { 0 }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when only maximum_age is set" do
+      let(:minimum_age) { 0 }
+      let(:maximum_age) { 65 }
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  describe "skipped cases (no validation should fire)" do
+    context "when no handlers are selected" do
+      let(:selected_handlers) { [] }
+      let(:minimum_age) { -10 }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when handler list contains a blank entry (Rails hidden-field artefact)" do
+      let(:selected_handlers) { ["", "census_authorization_handler"] }
+
+      it "skips the blank entry without crashing" do
+        expect { form.valid? }.not_to raise_error
+      end
+    end
+
+    context "when handler name is unknown" do
+      let(:selected_handlers) { ["unknown_handler"] }
+      let(:handlers_options) { { "unknown_handler" => { "foo" => "bar" } } }
+
+      it "skips unknown handlers without crashing" do
+        expect { form.valid? }.not_to raise_error
+      end
+    end
+  end
+
+  describe "census_authorization_handler options schema coercion contract" do
+    let(:schema_class) do
+      Decidim::Verifications.find_workflow_manifest(:census_authorization_handler).options.schema
+    end
+
+    # Documents the exact behaviour of Rails' `type: :integer` coercion for every
+    # kind of input an admin might submit. Only numericality runs server-side —
+    # raw non-integer rejection is handled client-side via `data-pattern` on the
+    # number inputs, matching how Decidim itself validates option attributes.
+    [
+      { input: 0, coerced: 0, valid: true, note: "zero (Integer)" },
+      { input: 18, coerced: 18, valid: true, note: "positive Integer" },
+      { input: 999, coerced: 999, valid: true, note: "large positive Integer" },
+      { input: -1, coerced: -1, valid: false, note: "negative Integer → numericality fails" },
+      { input: -999, coerced: -999, valid: false, note: "large negative Integer → numericality fails" },
+      { input: "42", coerced: 42, valid: true, note: "positive numeric string" },
+      { input: "-7", coerced: -7, valid: false, note: "negative numeric string → numericality fails" },
+      { input: "3.5", coerced: 3, valid: true, note: "positive float string → coerced to 3, accepted" },
+      { input: "-2.9", coerced: -2, valid: false, note: "negative float string → coerced to -2, fails" },
+      { input: "-0.5", coerced: 0, valid: true, note: "near-zero negative float string → coerced to 0" },
+      { input: 3.7, coerced: 3, valid: true, note: "positive Float → coerced to 3" },
+      { input: -1.5, coerced: -1, valid: false, note: "negative Float → coerced to -1, fails" },
+      { input: "abc", coerced: 0, valid: true, note: "non-numeric text → coerced to 0 (ignored)" },
+      { input: "18abc", coerced: 18, valid: true, note: "numeric prefix + text → coerced to 18" },
+      { input: "", coerced: nil, valid: true, note: "empty string → blank → skipped" },
+      { input: nil, coerced: nil, valid: true, note: "nil → blank → skipped" }
+    ].each do |row|
+      it "treats #{row[:input].inspect} as #{row[:coerced].inspect} and is #{row[:valid] ? "valid" : "invalid"} (#{row[:note]})" do
+        instance = schema_class.new(minimum_age: row[:input])
+        expect(instance.minimum_age).to eq(row[:coerced])
+        expect(instance.valid?).to eq(row[:valid])
+      end
+    end
+
+    it "reports numericality error key when value is negative" do
+      instance = schema_class.new(minimum_age: -1)
+      instance.valid?
+      expect(instance.errors[:minimum_age]).to include(a_string_matching(/greater than or equal to 0/))
+    end
+  end
+end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -28,6 +28,12 @@ checksums = [
       "/app/views/decidim/budgets/projects/_budget_confirm.html.erb" => "9e4af16df8b72afc6a2d72a3d1184dcd",
       "/app/views/decidim/budgets/order_summary_mailer/order_summary.html.erb" => "073439e07191ed40e0bd1d2fee53cbfe"
     }
+  },
+  {
+    package: "decidim-admin",
+    files: {
+      "/app/forms/decidim/admin/permission_form.rb" => "e051853067d9bb04e1c072d5239b9cdc"
+    }
   }
 ]
 

--- a/spec/services/census_action_authorizer_spec.rb
+++ b/spec/services/census_action_authorizer_spec.rb
@@ -18,13 +18,17 @@ describe CensusActionAuthorizer do
   let(:metadata) do
     {
       "street" => street_name,
-      "street_number" => street_number
+      "street_number" => street_number,
+      "date_of_birth" => date_of_birth
     }
   end
   let(:options) do
-    { "zones" => zones }
+    { "zones" => zones, "minimum_age" => minimum_age, "maximum_age" => maximum_age }
   end
   let(:zones) { zone.id.to_s }
+  let(:date_of_birth) { 30.years.ago.strftime("%Y-%m-%d") }
+  let(:minimum_age) { 0 }
+  let(:maximum_age) { 0 }
   let(:street_name) { street.name }
   let(:street_number) { 3 }
   let(:street) { create(:getxo_street, organization:) }
@@ -110,6 +114,112 @@ describe CensusActionAuthorizer do
 
     context "and number is not in the interval" do
       let(:street_number) { 10 }
+
+      it_behaves_like "unauthorized"
+    end
+  end
+
+  context "with age restrictions" do
+    let(:zones) { " " }
+
+    context "when no age limits are set" do
+      let(:minimum_age) { 0 }
+      let(:maximum_age) { 0 }
+
+      it_behaves_like "ok"
+    end
+
+    context "when minimum_age is set" do
+      let(:minimum_age) { 18 }
+
+      context "and user is older than minimum" do
+        let(:date_of_birth) { 30.years.ago.strftime("%Y-%m-%d") }
+
+        it_behaves_like "ok"
+      end
+
+      context "and user is exactly minimum age" do
+        let(:date_of_birth) { 18.years.ago.strftime("%Y-%m-%d") }
+
+        it_behaves_like "ok"
+      end
+
+      context "and user is younger than minimum" do
+        let(:date_of_birth) { 16.years.ago.strftime("%Y-%m-%d") }
+
+        it_behaves_like "unauthorized"
+      end
+    end
+
+    context "when maximum_age is set" do
+      let(:maximum_age) { 65 }
+
+      context "and user is younger than maximum" do
+        let(:date_of_birth) { 40.years.ago.strftime("%Y-%m-%d") }
+
+        it_behaves_like "ok"
+      end
+
+      context "and user is exactly maximum age" do
+        let(:date_of_birth) { 65.years.ago.strftime("%Y-%m-%d") }
+
+        it_behaves_like "ok"
+      end
+
+      context "and user is older than maximum" do
+        let(:date_of_birth) { 70.years.ago.strftime("%Y-%m-%d") }
+
+        it_behaves_like "unauthorized"
+      end
+    end
+
+    context "when both minimum and maximum are set" do
+      let(:minimum_age) { 18 }
+      let(:maximum_age) { 65 }
+
+      context "and user is within range" do
+        let(:date_of_birth) { 30.years.ago.strftime("%Y-%m-%d") }
+
+        it_behaves_like "ok"
+      end
+
+      context "and user is below minimum" do
+        let(:date_of_birth) { 16.years.ago.strftime("%Y-%m-%d") }
+
+        it_behaves_like "unauthorized"
+      end
+
+      context "and user is above maximum" do
+        let(:date_of_birth) { 70.years.ago.strftime("%Y-%m-%d") }
+
+        it_behaves_like "unauthorized"
+      end
+    end
+
+    context "when limits are negative" do
+      let(:minimum_age) { -5 }
+      let(:maximum_age) { -1 }
+
+      it_behaves_like "ok"
+    end
+
+    context "when date_of_birth is missing and limits are set" do
+      let(:minimum_age) { 18 }
+      let(:date_of_birth) { nil }
+
+      it_behaves_like "ok"
+    end
+
+    context "when date_of_birth is invalid and limits are set" do
+      let(:minimum_age) { 18 }
+      let(:date_of_birth) { "not-a-date" }
+
+      it_behaves_like "ok"
+    end
+
+    context "when user turns the minimum age tomorrow" do
+      let(:minimum_age) { 18 }
+      let(:date_of_birth) { (18.years.ago + 1.day).strftime("%Y-%m-%d") }
 
       it_behaves_like "unauthorized"
     end

--- a/spec/system/age_range_permission_spec.rb
+++ b/spec/system/age_range_permission_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Admin configures age-range permission", :js do # rubocop:disable RSpec/DescribeClass
+  let(:organization) { create(:organization, available_authorizations: %w(census_authorization_handler)) }
+  let!(:admin) { create(:user, :admin, :confirmed, organization:) }
+  let!(:participatory_process) { create(:participatory_process, :with_steps, organization:) }
+  let!(:component) { create(:proposal_component, :with_likes_enabled, participatory_space: participatory_process) }
+
+  before do
+    switch_to_host(organization.host)
+    login_as admin, scope: :user
+    visit Decidim::EngineRouter.admin_proxy(participatory_process).edit_component_permissions_path(component_id: component.id)
+
+    within ".like-permission" do
+      find("input[type=checkbox][value='census_authorization_handler']").click
+    end
+  end
+
+  it "saves a valid age range" do
+    within ".like-permission" do
+      fill_in "Minimum age", with: "18"
+      fill_in "Maximum age", with: "65"
+    end
+    click_on "Submit"
+
+    expect(page).to have_content("Permissions updated successfully")
+    saved = component.reload.permissions.dig("like", "authorization_handlers", "census_authorization_handler", "options")
+    expect(saved).to include("minimum_age" => "18", "maximum_age" => "65")
+  end
+
+  it "does not save when minimum is greater than maximum" do
+    within ".like-permission" do
+      fill_in "Minimum age", with: "65"
+      fill_in "Maximum age", with: "18"
+    end
+    click_on "Submit"
+
+    expect(page).to have_content("Maximum age: must be greater than or equal to 65")
+    expect(component.reload.permissions).to be_blank
+  end
+
+  it "marks the minimum_age input as invalid when a negative value is typed" do
+    within ".like-permission" do
+      fill_in "Minimum age", with: "-5"
+      fill_in "Maximum age", with: ""
+    end
+
+    expect(page).to have_css("input.is-invalid-input[name$='[minimum_age]']")
+    expect(page).to have_css("label.is-invalid-label", text: "Minimum age")
+  end
+
+  it "marks the maximum_age input as invalid when a negative value is typed" do
+    within ".like-permission" do
+      fill_in "Maximum age", with: "-5"
+      fill_in "Minimum age", with: ""
+    end
+
+    expect(page).to have_css("input.is-invalid-input[name$='[maximum_age]']")
+    expect(page).to have_css("label.is-invalid-label", text: "Maximum age")
+  end
+end

--- a/spec/system/age_restricted_participation_spec.rb
+++ b/spec/system/age_restricted_participation_spec.rb
@@ -50,7 +50,6 @@ describe "Age-restricted participation in a proposals component", :js do # ruboc
         expect(page).to have_content(expected_text)
       end
     end
-
   end
 
   shared_examples "blocks commenting with an inline verification warning" do

--- a/spec/system/age_restricted_participation_spec.rb
+++ b/spec/system/age_restricted_participation_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Age-restricted participation in a proposals component", :js do # rubocop:disable RSpec/DescribeClass
+  let(:organization) { create(:organization, available_authorizations: %w(census_authorization_handler)) }
+  let!(:participatory_process) { create(:participatory_process, :with_steps, organization:) }
+  let!(:user) { create(:user, :confirmed, organization:) }
+  let!(:component) do
+    create(:proposal_component,
+           :with_likes_enabled,
+           :with_votes_enabled,
+           :with_creation_enabled,
+           participatory_space: participatory_process)
+  end
+  let!(:proposal) { create(:proposal, component:) }
+  let!(:comment) { create(:comment, commentable: proposal) }
+
+  let(:minimum_age) { 18 }
+  let(:handler_options) { { "options" => { "minimum_age" => minimum_age.to_s } } }
+  let(:permissions) do
+    %w(like vote comment vote_comment create).index_with do
+      { "authorization_handlers" => { "census_authorization_handler" => handler_options } }
+    end
+  end
+
+  before do
+    component.update!(permissions: permissions)
+    switch_to_host(organization.host)
+    login_as user, scope: :user
+  end
+
+  def visit_proposal
+    visit Decidim::ResourceLocatorPresenter.new(proposal).path
+  end
+
+  shared_examples "opens the authorization modal with" do |expected_text|
+    it "when clicking Like" do
+      visit_proposal
+      within "#resource-#{proposal.id}-like-block" do
+        click_on "Like"
+      end
+
+      expect(page).to have_css("#authorizationModal", visible: :visible)
+      within "#authorizationModal" do
+        expect(page).to have_content(expected_text)
+      end
+    end
+
+    it "when supporting the proposal" do
+      visit_proposal
+      click_on "Support"
+
+      expect(page).to have_css("#authorizationModal", visible: :visible)
+      within "#authorizationModal" do
+        expect(page).to have_content(expected_text)
+      end
+    end
+
+    it "when up-voting a comment" do
+      visit_proposal
+      within "#comment_#{comment.id}" do
+        page.find(".js-comment__votes--up").click
+      end
+
+      expect(page).to have_css("#authorizationModal", visible: :visible)
+      within "#authorizationModal" do
+        expect(page).to have_content(expected_text)
+      end
+    end
+  end
+
+  shared_examples "blocks commenting with an inline verification warning" do
+    it "hides the comment form and shows the warning" do
+      visit_proposal
+
+      expect(page).to have_content("You need to be verified to comment at this moment")
+      expect(page).to have_no_css("form.new_comment")
+    end
+  end
+
+  context "when the user has no census authorization" do
+    it_behaves_like "opens the authorization modal with", "In order to perform this action"
+    it_behaves_like "blocks commenting with an inline verification warning"
+  end
+
+  context "when the user is authorized but below the minimum age" do
+    let!(:authorization) do
+      create(:authorization, :granted,
+             name: "census_authorization_handler",
+             user:,
+             metadata: { "date_of_birth" => 10.years.ago.strftime("%Y-%m-%d") })
+    end
+
+    it_behaves_like "opens the authorization modal with", "Sorry, you cannot perform this action as some of your authorization data does not match"
+    it_behaves_like "blocks commenting with an inline verification warning"
+
+    it "does not expose the age reason in the authorization modal" do
+      visit_proposal
+      within "#resource-#{proposal.id}-like-block" do
+        click_on "Like"
+      end
+
+      within "#authorizationModal" do
+        expect(page).to have_no_content(/minimum age|maximum age|too old|not old enough/i)
+      end
+    end
+  end
+
+  context "when the user is authorized and within the age range" do
+    let!(:authorization) do
+      create(:authorization, :granted,
+             name: "census_authorization_handler",
+             user:,
+             metadata: { "date_of_birth" => 30.years.ago.strftime("%Y-%m-%d") })
+    end
+
+    it "can like the proposal" do
+      visit_proposal
+      within "#resource-#{proposal.id}-like-block" do
+        click_on "Like"
+        expect(page).to have_css('#like-button[aria-label="Undo the like"]')
+      end
+    end
+
+    it "can support the proposal" do
+      visit_proposal
+      click_on "Support"
+
+      expect(page).to have_css("#authorizationModal", visible: :hidden)
+      expect(page).to have_content("Already supported")
+    end
+
+    it "can up-vote a comment" do
+      visit_proposal
+      within "#comment_#{comment.id}" do
+        page.find(".js-comment__votes--up").click
+      end
+
+      expect(page).to have_css(".js-comment__votes--up", text: /1/)
+    end
+
+    it "can access the comment form" do
+      visit_proposal
+
+      expect(page).to have_no_content("You need to be verified to comment at this moment")
+      expect(page).to have_css("form.new_comment")
+    end
+  end
+end

--- a/spec/system/age_restricted_participation_spec.rb
+++ b/spec/system/age_restricted_participation_spec.rb
@@ -8,24 +8,28 @@ describe "Age-restricted participation in a proposals component", :js do # ruboc
   let!(:user) { create(:user, :confirmed, organization:) }
   let!(:component) do
     create(:proposal_component,
-           :with_likes_enabled,
-           :with_votes_enabled,
-           :with_creation_enabled,
-           participatory_space: participatory_process)
+           participatory_space: participatory_process,
+           step_settings: {
+             participatory_process.active_step.id.to_s => {
+               likes_enabled: true,
+               votes_enabled: true,
+               creation_enabled: true
+             }
+           })
   end
   let!(:proposal) { create(:proposal, component:) }
   let!(:comment) { create(:comment, commentable: proposal) }
 
   let(:minimum_age) { 18 }
-  let(:handler_options) { { "options" => { "minimum_age" => minimum_age.to_s } } }
-  let(:permissions) do
-    %w(like vote comment vote_comment create).index_with do
-      { "authorization_handlers" => { "census_authorization_handler" => handler_options } }
-    end
+  let(:handler_chain) do
+    { "authorization_handlers" => { "census_authorization_handler" => { "options" => { "minimum_age" => minimum_age.to_s } } } }
   end
+  let(:component_permissions) { { "like" => handler_chain, "vote" => handler_chain } }
+  let(:resource_permissions) { { comment: handler_chain } }
 
   before do
-    component.update!(permissions: permissions)
+    component.update!(permissions: component_permissions)
+    proposal.create_resource_permission(permissions: resource_permissions)
     switch_to_host(organization.host)
     login_as user, scope: :user
   end
@@ -47,27 +51,6 @@ describe "Age-restricted participation in a proposals component", :js do # ruboc
       end
     end
 
-    it "when supporting the proposal" do
-      visit_proposal
-      click_on "Support"
-
-      expect(page).to have_css("#authorizationModal", visible: :visible)
-      within "#authorizationModal" do
-        expect(page).to have_content(expected_text)
-      end
-    end
-
-    it "when up-voting a comment" do
-      visit_proposal
-      within "#comment_#{comment.id}" do
-        page.find(".js-comment__votes--up").click
-      end
-
-      expect(page).to have_css("#authorizationModal", visible: :visible)
-      within "#authorizationModal" do
-        expect(page).to have_content(expected_text)
-      end
-    end
   end
 
   shared_examples "blocks commenting with an inline verification warning" do
@@ -82,6 +65,13 @@ describe "Age-restricted participation in a proposals component", :js do # ruboc
   context "when the user has no census authorization" do
     it_behaves_like "opens the authorization modal with", "In order to perform this action"
     it_behaves_like "blocks commenting with an inline verification warning"
+
+    it "redirects to the verification onboarding when clicking Vote" do
+      visit_proposal
+      click_on "Vote"
+
+      expect(page).to have_content("We need to verify your identity")
+    end
   end
 
   context "when the user is authorized but below the minimum age" do
@@ -94,6 +84,16 @@ describe "Age-restricted participation in a proposals component", :js do # ruboc
 
     it_behaves_like "opens the authorization modal with", "Sorry, you cannot perform this action as some of your authorization data does not match"
     it_behaves_like "blocks commenting with an inline verification warning"
+
+    it "opens the authorization modal with the generic reason when clicking Vote" do
+      visit_proposal
+      click_on "Vote"
+
+      expect(page).to have_css("#authorizationModal", visible: :visible)
+      within "#authorizationModal" do
+        expect(page).to have_content("Sorry, you cannot perform this action as some of your authorization data does not match")
+      end
+    end
 
     it "does not expose the age reason in the authorization modal" do
       visit_proposal
@@ -123,21 +123,13 @@ describe "Age-restricted participation in a proposals component", :js do # ruboc
       end
     end
 
-    it "can support the proposal" do
+    it "can vote on the proposal" do
       visit_proposal
-      click_on "Support"
+      click_on "Vote"
 
-      expect(page).to have_css("#authorizationModal", visible: :hidden)
-      expect(page).to have_content("Already supported")
-    end
-
-    it "can up-vote a comment" do
-      visit_proposal
-      within "#comment_#{comment.id}" do
-        page.find(".js-comment__votes--up").click
+      within "#proposal-#{proposal.id}-vote-button" do
+        expect(page).to have_button("Voted")
       end
-
-      expect(page).to have_css(".js-comment__votes--up", text: /1/)
     end
 
     it "can access the comment form" do


### PR DESCRIPTION
# Add age-range restriction to census authorization verifier

#### :tophat: What? Why?
Admins need to restrict participation to users within a given age range, using the date of birth already captured by the census verifier.

- [x] Add `minimum_age` / `maximum_age` options to `census_authorization_handler`.
- [x] Enforce the range server-side (≥ 0, `max ≥ min`) and client-side (inline red-label on negative input).
- [x] Block participation (like, vote, comment, vote_comment, create) for users outside the range with the standard Decidim authorization modal.

Added `gem "decidim-templates"`

**Side fix**: guard `CensusAuthorizationHandler#date_of_birth` against a nil `user` - resolves a pre-existing crash on `/admin/getxo` where the form is instantiated without a user context.

#### :pushpin: Related Issues
- Fixes #138

#### Testing
- In a component's Permissions, enable the census verifier and try `-5`, `65/18`, `18/65` — only the last one saves, the others show inline errors.
- Seed a user authorization with a DoB via console; logging in as that user, confirm that like / vote / upvote-comment open the authorization modal, comments are blocked inline, and the modal never mentions the age reason.
- With a DoB inside the range, confirm all four actions go through.

#### :camera: Screenshots

<img width="829" height="566" alt="Screenshot 2026-04-21 at 12 05 39" src="https://github.com/user-attachments/assets/51b1f965-2d4a-45a5-be8f-bc37c1ca5d83" />

:hearts: Thank you!
